### PR TITLE
Restart PulseAudio on hardware change

### DIFF
--- a/rootfs/etc/services.d/alsa/run
+++ b/rootfs/etc/services.d/alsa/run
@@ -21,4 +21,8 @@ while read -r line; do
     # Run our soundconfig
     soundconfig "${control}"
 
+    # Restart PulseAudio
+    s6-svc -wD -d -T2500 "/var/run/s6/services/pulseaudio"
+    s6-svc -wU -u -T2500 "/var/run/s6/services/pulseaudio"
+
 done < <(udevadm monitor --subsystem-match=sound)


### PR DESCRIPTION
A container gets only Kernel udev events. But all applications want udev daemon events and they are not available. This solve that issue and we restart PulseAudio to get the new data from udev.