### PR TITLE
Add Khadas VIM3 support

### DIFF
--- a/rootfs/usr/bin/soundconfig
+++ b/rootfs/usr/bin/soundconfig
@@ -17,7 +17,8 @@ mixer() {
 . /etc/profile
 
 # get card num
-card=`echo $1 | sed 's/[^0-9]*//g'`
+card=$(echo $1 | sed 's/[^0-9]*//g')
+dtcompatible=$(cat /proc/device-tree/compatible | cut -f1 -d '' | head -n 1)
 
 # set common mixer params
 mixer $card Master 0db
@@ -117,20 +118,31 @@ mixer $card 'Power Amplifier Mute' on
 mixer $card Headphone 0db on
 mixer $card 'AIF1 Slot 0 Digital DAC' on
 
-# Amlogic G12 HDMI to PCM0
-mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 1'
-mixer $card 'FRDDR_A SRC 1 EN' on
-mixer $card 'TDMOUT_B SRC SEL' 'IN 0'
-mixer $card 'TOHDMITX I2S SRC' 'I2S B'
-mixer $card 'TOHDMITX' on
+case "$dtcompatible" in
+  hardkernel,odroid-n2*)
+    # Amlogic G12 HDMI to PCM0
+    mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 1'
+    mixer $card 'FRDDR_A SRC 1 EN' on
+    mixer $card 'TDMOUT_B SRC SEL' 'IN 0'
+    mixer $card 'TOHDMITX I2S SRC' 'I2S B'
+    mixer $card 'TOHDMITX' on
 
-# Amlogic G12 DAC to PCM1
-mixer $card 'FRDDR_B SINK 1 SEL' 'OUT 2'
-mixer $card 'FRDDR_B SRC 1 EN' on
-mixer $card 'TDMOUT_C SRC SEL' 'IN 1'
-mixer $card 'TOACODEC SRC' 'I2S C'
-mixer $card 'TOACODEC OUT EN' on
-mixer $card 'ACODEC' 100%
+    # Amlogic G12 DAC to PCM1
+    mixer $card 'FRDDR_B SINK 1 SEL' 'OUT 2'
+    mixer $card 'FRDDR_B SRC 1 EN' on
+    mixer $card 'TDMOUT_C SRC SEL' 'IN 1'
+    mixer $card 'TOACODEC SRC' 'I2S C'
+    mixer $card 'TOACODEC OUT EN' on
+    mixer $card 'ACODEC' 100%
+    ;;
+  khadas,vim3*)
+    mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 0'
+    mixer $card 'FRDDR_A SRC 1 EN' on
+    mixer $card 'TDMOUT_A SRC SEL' 'IN 0'
+    mixer $card 'TOHDMITX' on
+    mixer $card 'TOHDMITX I2S SRC' 'I2S A'
+    ;;
+esac
 
 # Amlogic GX HDMI and S/PDIF
 mixer $card 'AIU HDMI CTRL SRC' 'I2S'


### PR DESCRIPTION
Add sound configuration for Khadas VIM3. Currently only HDMI supported.
This requires access to device tree in sysfs.