### PR TITLE
Remove verbose logging for pulseaudio

### DIFF
--- a/rootfs/etc/services.d/pulseaudio/run
+++ b/rootfs/etc/services.d/pulseaudio/run
@@ -5,4 +5,4 @@
 export PULSE_STATE_PATH="/data/states"
 export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
 
-exec pulseaudio --system -vvv --disallow-exit --exit-idle-time=-1 --disable-shm
+exec pulseaudio --system --disallow-exit --exit-idle-time=-1 --disable-shm


### PR DESCRIPTION
Verbose logging can be useful for debugging but it accumulates in `syslog` and can fill disks.