### PR TITLE
Verbose logging only if in debug mode

### DIFF
--- a/rootfs/etc/services.d/pulseaudio/run
+++ b/rootfs/etc/services.d/pulseaudio/run
@@ -8,7 +8,7 @@ export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
 debug="$(jq '.debug' /config/plugin_audio.json)"
 log_level=""
 
-if [ "$debug" == 'true']; then
+if [ "$debug" = "true" ]; then
   log_level='-vvv'
 fi
 

--- a/rootfs/etc/services.d/pulseaudio/run
+++ b/rootfs/etc/services.d/pulseaudio/run
@@ -5,10 +5,10 @@
 export PULSE_STATE_PATH="/data/states"
 export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
 
-debug="$(jq '.debug' /config/plugin_audio.json)"
+debug="$(bashio::jq /config/plugin_audio.json '.debug')"
 log_level=""
 
-if [ "$debug" = "true" ]; then
+if bashio::var.true "${debug}"; then
   log_level='-vvv'
 fi
 

--- a/rootfs/etc/services.d/pulseaudio/run
+++ b/rootfs/etc/services.d/pulseaudio/run
@@ -5,4 +5,11 @@
 export PULSE_STATE_PATH="/data/states"
 export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
 
-exec pulseaudio --system -vvv --disallow-exit --exit-idle-time=-1 --disable-shm
+debug="$(jq '.debug' /config/plugin_audio.json)"
+log_level=""
+
+if [ "$debug" == 'true']; then
+  log_level='-vvv'
+fi
+
+exec pulseaudio --system --disallow-exit --exit-idle-time=-1 --disable-shm "$log_level"


### PR DESCRIPTION
Only do verbose logging if supervisor is in debug mode, otherwise drop `-vvv` from command.

Parent PR: https://github.com/home-assistant/supervisor/pull/3752

Supercedes #85 

Fixes #57
Fixes #56