### PR TITLE
Amlogic ALSA configuration file fixes

### DIFF
--- a/rootfs/usr/share/alsa/cards/KHADAS-VIM3.conf
+++ b/rootfs/usr/share/alsa/cards/KHADAS-VIM3.conf
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2020-present Home Assistant (https://home-assistant.io)
+
+<confdir:pcm/hdmi.conf>
+
+KHADAS-VIM3.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 0
+		subdevice 0
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				interface MIXER
+				name "IEC958 Playback Default"
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+	hint.device 0
+}
+
+<confdir:pcm/front.conf>
+
+KHADAS-VIM3.pcm.front.0 {
+        @args [ CARD ]
+	@args.CARD { type string }
+	type softvol
+	slave.pcm {
+		type hw
+		card $CARD
+                device 1
+		subdevice 0
+	}
+	control {
+		name "Onboard DAC output"
+		card $CARD
+	}
+}

--- a/rootfs/usr/share/alsa/cards/axg-sound-card.conf
+++ b/rootfs/usr/share/alsa/cards/axg-sound-card.conf
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2020-present Home Assistant (https://home-assistant.io)
+
+<confdir:pcm/hdmi.conf>
+
+axg-sound-card.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 0
+		subdevice 0
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				interface MIXER
+				name "IEC958 Playback Default"
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+	hint.device 0
+}
+
+<confdir:pcm/front.conf>
+
+axg-sound-card.pcm.front.0 {
+        @args [ CARD ]
+	@args.CARD { type string }
+	type softvol
+	slave.pcm {
+		type hw
+		card $CARD
+                device 1
+		subdevice 0
+	}
+	control {
+		name "Onboard DAC output"
+		card $CARD
+	}
+}

--- a/rootfs/usr/share/alsa/cards/gx-sound-card.conf
+++ b/rootfs/usr/share/alsa/cards/gx-sound-card.conf
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+<confdir:pcm/hdmi.conf>
+
+gx-sound-card.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 0
+		subdevice 0
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				interface MIXER
+				name "IEC958 Playback Default"
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+	hint.device 0
+}


### PR DESCRIPTION
Use new driver name for ALSA configuration

With Linux kernel commit [bc387887ae22 ("ASoC: meson: implement
driver_name for snd_soc_card in meson-card-utils")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bc387887ae22d6ed6439e83968b5be3443a8e57d) the Meson ASoC
driver passes the driver name (seemingly derrived from device tree
"compatible") to ALSA. This then reflects in /proc/asound/cards, which
now lists "axg-sound-card", instead of ODROID-N2 (derrived from the
device tree "model"):

Since Linux 5.16+
```
  # cat  /proc/asound/cards
   0 [ODROIDN2       ]: axg-sound-card - ODROID-N2
                        ODROID-N2
```

Linux 5.15 and earlier:
```
  # cat /proc/asound/cards
   0 [ODROIDN2       ]: ODROID-N2 - ODROID-N2
                        ODROID-N2
```

It seems that this string is used to find the ALSA configuration in
/usr/share/alsa/cards/.

Note that the same string is used in Khadas VIM3. But since the two
configuration files are the same, this actually deduplicate things.

Similarly, use new driver name for ALSA configuration for ODROID-C2.

Also add a missing configuration file for Khadas VIM3 and HAOS 9.5.