### PR TITLE
Fix Audio on ODROID-C4

### DIFF
--- a/rootfs/usr/bin/soundconfig
+++ b/rootfs/usr/bin/soundconfig
@@ -129,6 +129,14 @@ case ${device_id} in
     # Yellow - set Analogue Gain to -6dB for line-out circuit
     mixer $card 'Analogue' 0
     ;;
+  ODROIDC4)
+    # Amlogic G12 HDMI to PCM0
+    mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 1'
+    mixer $card 'FRDDR_A SRC 1 EN' on
+    mixer $card 'TDMOUT_B SRC SEL' 'IN 0'
+    mixer $card 'TOHDMITX I2S SRC' 'I2S B'
+    mixer $card 'TOHDMITX' on
+    ;;
   G12BODROIDN2|ODROIDN2)
     # Amlogic G12 HDMI to PCM0
     mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 1'


### PR DESCRIPTION
With the new axg-sound-card sound card configuration ODROID-C4 gets a valid sound card now. However, startup doesn't complete since the sound card is not properly setup due to missing soundconfig. This leads to 100% CPU usage by the Audio plug-in on ODROID-C4.

This adds soundconfig for ODROID-C4 to fix the problem.

Fixes: https://github.com/home-assistant/operating-system/issues/2510