### PR TITLE
Bump to Alsa 1.2.10/Alpine 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN \
         eudev \
         libintl \
         libltdl \
+        libgcc \
+        libstdc++ \
         alsa-utils \
         alsa-lib \
         alsa-plugins-pulse \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN \
         eudev \
         libintl \
         libltdl \
-        libgcc \
-        libstdc++ \
         alsa-utils \
         alsa-lib \
         alsa-plugins-pulse \

--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-hassio-audio
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.17
-  armhf: ghcr.io/home-assistant/armhf-base:3.17
-  armv7: ghcr.io/home-assistant/armv7-base:3.17
-  amd64: ghcr.io/home-assistant/amd64-base:3.17
-  i386: ghcr.io/home-assistant/i386-base:3.17
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
+  armhf: ghcr.io/home-assistant/armhf-base:3.19
+  armv7: ghcr.io/home-assistant/armv7-base:3.19
+  amd64: ghcr.io/home-assistant/amd64-base:3.19
+  i386: ghcr.io/home-assistant/i386-base:3.19
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
@@ -12,7 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/plugin-audio/.*
 args:
-  ALSA_LIB_VERSION: 1.2.8
+  ALSA_LIB_VERSION: 1.2.10
   ALSA_TOOLS_VERSION: 1.2.5
   PULSE_VERSION: 16.1
 labels:


### PR DESCRIPTION
~~Also add libstdc++ explicitly which is required for jemalloc. This is not part of the base image. Previouly this library (and libgcc which is a dependency of it) got intstalled implicitly by libsndfile, which used to depend on flac-libs which in turn depends on libstdc++.~~

libstdc++ and libgcc are now part of the base image, see https://github.com/home-assistant/docker-base/pull/253.
