### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,11 @@
+---
+name: Stale
+
+on:
+  schedule:
+    - cron: "45 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  workflows:
+    uses: home-assistant/actions/.github/workflows/stale.yaml@master


### PR DESCRIPTION
Add standard Home Assistant stale workflow (mark stale after 30 days then close after 7 additional days).