### PR TITLE
Bump to Pulseaduio 17.0 and Alpine 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM ${BUILD_FROM}
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
-ARG ALSA_LIB_VERSION
-ARG ALSA_TOOLS_VERSION
 ARG PULSE_VERSION
 
 COPY patches /usr/src/patches
@@ -12,11 +10,14 @@ RUN \
     set -x \
     && apk add --no-cache \
         eudev \
+        eudev-libs \
         libintl \
         libltdl \
         alsa-utils \
         alsa-lib \
         alsa-plugins-pulse \
+        alsa-topology-conf \
+        alsa-ucm-conf \
         dbus-libs \
         tdb-libs \
         bluez-libs \
@@ -45,14 +46,6 @@ RUN \
         git \
         m4 \
         patch \
-    \
-    && curl -L -s --retry 5 \
-        "https://www.alsa-project.org/files/pub/lib/alsa-ucm-conf-${ALSA_LIB_VERSION}.tar.bz2" \
-        | tar xvfj - -C /usr/share/alsa --strip-components=1 \
-    \
-    && curl -L -s --retry 5 \
-        "https://www.alsa-project.org/files/pub/lib/alsa-topology-conf-${ALSA_TOOLS_VERSION}.tar.bz2" \
-        | tar xvfj - -C /usr/share/alsa --strip-components=1 \
     \
     && git clone -b v${PULSE_VERSION} --depth 1 \
         https://github.com/pulseaudio/pulseaudio /usr/src/pulseaudio \

--- a/build.yaml
+++ b/build.yaml
@@ -12,7 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/plugin-audio/.*
 args:
-  PULSE_VERSION: 17.0
+  PULSE_VERSION: "17.0"
 labels:
   io.hass.type: audio
   org.opencontainers.image.title: Home Assistant Audio Plugin

--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-hassio-audio
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+  armhf: ghcr.io/home-assistant/armhf-base:3.21
+  armv7: ghcr.io/home-assistant/armv7-base:3.21
+  amd64: ghcr.io/home-assistant/amd64-base:3.21
+  i386: ghcr.io/home-assistant/i386-base:3.21
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
@@ -12,9 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/plugin-audio/.*
 args:
-  ALSA_LIB_VERSION: 1.2.10
-  ALSA_TOOLS_VERSION: 1.2.5
-  PULSE_VERSION: 16.1
+  PULSE_VERSION: 17.0
 labels:
   io.hass.type: audio
   org.opencontainers.image.title: Home Assistant Audio Plugin


### PR DESCRIPTION
This bumps the Audio plug-in to Alpine 3.21 and Pulseaudio 17.0. Also move to the Alpine versions of the ALSA topology and UCM configuration. There is no point in extracting the same file from upstream tarballs instead of using the Alpine packages.