### PR TITLE
Add ability to add custom PulseAudio startup commands

### DIFF
--- a/rootfs/etc/pulse/system.pa
+++ b/rootfs/etc/pulse/system.pa
@@ -46,6 +46,12 @@ load-module module-always-sink
 ### Enable positioned event sounds
 load-module module-position-event-sounds
 
-.ifexists /data/custom.pa
+# Load additional user configuration, if present
+#
+# Using nofail has two effects here:
+#  1) Causes PulseAudio to log a message at startup if the user configuration
+#     is not present to increase visible of the corresponding configuration
+#     (cli-command.c: stat('/data/custom.pa'): No such file or directory)
+#  2) Means broken user command in the given file will not make PulseAudio fail
+.nofail
 .include /data/custom.pa
-.endif

--- a/rootfs/etc/pulse/system.pa
+++ b/rootfs/etc/pulse/system.pa
@@ -45,3 +45,7 @@ load-module module-always-sink
 
 ### Enable positioned event sounds
 load-module module-position-event-sounds
+
+.ifexists /data/custom.pa
+.include /data/custom.pa
+.endif


### PR DESCRIPTION
Loads two extra “user-configurable” configuration files:

/mnt/data/supervisor/audio/override.pa
… replaces the default configuration, if present.

/mnt/data/supervisor/audio/custom.pa
… is appended to the default configuration, if present.

Tested and working… but kinda requires at least *Advanced Terminal & SSH* (if not host access) to be useful given how complicated it is to access these files.

Minimally addresses #178.