### PR TITLE
Update Renovate config, pin base image to SHA

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,26 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["custom.regex"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["^Dockerfile$"],
-      "matchStrings": [
-        "BUILD_FROM=(?<image>ghcr\\.io/home-assistant/base:(?<alpineVersion>alpine[0-9\\.]+))-(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "home-assistant/docker-base"
-    }
-  ],
+  "enabledManagers": ["dockerfile"],
+  "ignorePaths": [".devcontainer/**"],
   "packageRules": [
     {
-      "matchDatasources": ["github-releases"],
-      "matchDepNames": ["home-assistant/docker-base"],
-      "groupName": "docker-base",
-      "commitMessageTopic": "home-assistant/docker-base image",
-      "commitMessageExtra": "to {{newVersion}}",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/home-assistant/base"],
+      "versionCompatibility": "^3\\.23-(?<version>\\d+\\.\\d+\\.\\d+)$",
       "versioning": "pep440",
-      "minimumReleaseAge": "1 hour"
+      "sourceUrl": "https://github.com/home-assistant/docker-base",
+      "groupName": "docker-base",
+      "commitMessageTopic": "home-assistant/base image",
+      "commitMessageExtra": "to {{newValue}}"
     }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/base:3.23-2026.03.1
-FROM ${BUILD_FROM}
+# Base image updated by Renovate, update versionCompatibility on Alpine base bump
+FROM ghcr.io/home-assistant/base:3.23-2026.03.1@sha256:c20ba24722be474428ceee385860c3c17acc48630eb0a6b26cbeb7005406058f
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Use dockerfile manager to update the base image on a new release including a pinned SHA of the multi-arch manifest. Same as home-assistant/cli#201.