### PR TITLE
Bump Alpine base to 3.24-2026.06.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/home-assistant/base"],
-      "versionCompatibility": "^3\\.23-(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "versionCompatibility": "^3\\.24-(?<version>\\d+\\.\\d+\\.\\d+)$",
       "versioning": "pep440",
       "sourceUrl": "https://github.com/home-assistant/docker-base",
       "groupName": "docker-base",

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -73,7 +73,7 @@ jobs:
           arch: ${{ matrix.arch }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           cosign-base-identity: 'https://github.com/home-assistant/docker-base/.*'
-          cosign-base-verify: ghcr.io/home-assistant/base:3.23
+          cosign-base-verify: ghcr.io/home-assistant/base:3.24
           image: ${{ matrix.image }}
           image-tags: |
             ${{ needs.init.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image updated by Renovate, update versionCompatibility on Alpine base bump
-FROM ghcr.io/home-assistant/base:3.23-2026.06.1@sha256:445077433f08d1e352285ff22ee2594f6b93ac3260dcf84433c79cd849a946a0
+FROM ghcr.io/home-assistant/base:3.24-2026.06.1@sha256:94ff231402a5e7ad2a82e261ad5fa4ffae7d7bb095c3febb2edbdf309c9b6aca
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Bumps the Home Assistant base image from Alpine 3.23 to 3.24 (`3.24-2026.06.1`),
updates the Renovate `versionCompatibility` pattern so future base updates stay
on the 3.24 line, and points the cosign base verification at the 3.24 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)