### PR TITLE
Skip s6 SIGTERM-to-SIGKILL grace time at container stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM ghcr.io/home-assistant/base:3.24-2026.06.1@sha256:94ff231402a5e7ad2a82e261a
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
+# Everything in this image runs s6-supervised and is stopped gracefully
+# by s6-rc: skip the blind SIGTERM-to-SIGKILL grace sleep at shutdown.
+ENV S6_KILL_GRACETIME=0
+
 ARG PULSE_VERSION="17.0"
 
 RUN \


### PR DESCRIPTION
## Description

At container shutdown, after s6-rc has stopped all services gracefully, `s6-linux-init-shutdownd` broadcasts SIGTERM, sleeps a fixed `S6_KILL_GRACETIME` (default 3000 ms), and broadcasts SIGKILL. The sleep is unconditional ([upstream source](https://github.com/skarnet/s6-linux-init/blob/master/src/shutdown/s6-linux-init-shutdownd.c)):

```c
kill(-1, SIGTERM) ;
kill(-1, SIGCONT) ;
tain_from_millisecs(&deadline, grace_time) ;
...
deepsleepuntil_g(&deadline) ;
kill(-1, SIGKILL) ;
```

It is a grace window for processes running *outside* s6 supervision — s6 has no way to check whether any exist. 

During a Home Assistant OS shutdown the Supervisor stops its plugin containers sequentially, so these windows add up to ~15 s of dead time per reboot (measured on a generic-x86-64 install, visible thanks to home-assistant/operating-system#4923).

Measurement against the current base image (3.24, s6-overlay 3.2.2.0): `docker stop` 3.18 s → 0.18 s.

**Reviewer caveat:** this is only safe for images where everything runs under s6 supervision. A container CMD is *not* stopped by s6-rc — on `docker stop`, a CMD's only graceful-exit window is exactly this grace time. This image has no CMD.Everything in this image runs as a supervised s6 service (PulseAudio, plus the ALSA oneshots via s6-rc), so every stop of `hassio_audio` idles for a flat 3 seconds after the services are already down — measured 3.04 s on HAOS, with the actual service stop well under 100 ms.

Same change for the other plugins: home-assistant/plugin-dns#203 (and home-assistant/plugin-dns#204 as a variant with a stray-process detection tripwire — if that variant is preferred, the same can follow here). plugin-observer is not affected: it does not run s6 at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
