### PR TITLE
Add ability to add custom PulseAudio configurations

### DIFF
--- a/rootfs/etc/pulse/daemon.conf
+++ b/rootfs/etc/pulse/daemon.conf
@@ -88,4 +88,5 @@
 ; deferred-volume-safety-margin-usec = 8000
 ; deferred-volume-extra-delay-usec = 0
 
+# Load additional or override user configuration, if present
 .include /data/custom.conf

--- a/rootfs/etc/pulse/daemon.conf
+++ b/rootfs/etc/pulse/daemon.conf
@@ -87,3 +87,5 @@
 ; enable-deferred-volume = yes
 ; deferred-volume-safety-margin-usec = 8000
 ; deferred-volume-extra-delay-usec = 0
+
+.include /data/custom.conf


### PR DESCRIPTION
This PR adds '.include /data/custom.conf' to the end of /etc/pulse/daemon.conf so that the defaults can be overridden, similar to the way #197 does this for PA commands.

Tested with  /data/custom.conf containing:
default-sample-format = s24le
default-sample-rate = 96000

After doing a ha audio restart the new sample rates and bit depths were applied to the cards.  

From https://wiki.archlinux.org/title/PulseAudio/Examples
```

PulseAudio/Examples

Creating user configuration files

System-wide configuration files are located under /etc/pulse/ while user configuration files are located under $XDG_CONFIG_HOME/pulse/, which defaults to ~/.config/pulse/. For the examples below which modify the user's configuration file it may be necessary to first create the file. This can be done either by copying the system file under /etc/pulse/ to the user's configuration directory, or by creating a new file that includes it with the syntax .include /etc/pulse/name. For simple changes the latter is preferred because the user will not be required to update the file when system-wide defaults change.
User client configuration file example

~/.config/pulse/client.conf

.include /etc/pulse/client.conf
# User's directives go here.

This syntax works for default.pa, daemon.conf and system.pa, even if the latter makes no sense as a user configuration file.

```

Testing steps:
```

➜  ~ pactl list sinks short           
0       alsa_output.pci-0000_01_00.0.analog-surround-71 module-alsa-card.c      s16le 8ch 44100Hz       IDLE
1       alsa_output.pci-0000_04_00.0.analog-surround-71 module-alsa-card.c      s16le 8ch 44100Hz       IDLE
2       alsa_output.usb-AudioQuest_AudioQuest_DragonFly_Black_v1.5_AQDFBL0120005724-00.iec958-stereo    module-alsa-card.c      s24le 2ch 44100Hz       IDLE
3       alsa_output.usb-Generic_ELEGIANT_SR030_20170726905959-00.analog-stereo  module-alsa-card.c      s16le 2ch 48000Hz       IDLE
4       alsa_output.pci-0000_08_00.6.analog-surround-51 module-alsa-card.c      s16le 6ch 44100Hz       IDLE
➜  ~ docker exec -it hassio_audio bash

hassio-audio:/# nano  /data/custom.conf

## 
added these line to /data/custom.conf:
default-sample-format = s24le
default-sample-rate = 96000
##

➜  ~ ha audio restart                 
Processing... Done.

Command completed successfully.
➜  ~ pactl list sinks short
0       alsa_output.pci-0000_01_00.0.analog-surround-71 module-alsa-card.c      s24le 8ch 96000Hz       IDLE
1       alsa_output.pci-0000_04_00.0.analog-surround-71 module-alsa-card.c      s24le 8ch 96000Hz       IDLE
2       alsa_output.usb-AudioQuest_AudioQuest_DragonFly_Black_v1.5_AQDFBL0120005724-00.iec958-stereo    module-alsa-card.c      s24le 2ch 96000Hz       IDLE
3       alsa_output.usb-Generic_ELEGIANT_SR030_20170726905959-00.analog-stereo  module-alsa-card.c      s16le 2ch 48000Hz       IDLE
4       alsa_output.pci-0000_08_00.6.analog-surround-51 module-alsa-card.c      s32le 6ch 96000Hz       IDLE
➜  ~ 
``` 

Here is a one line docker command example to run in a terminal that will create the file and add the lines to the custom.conf.  Edit it and add to it as needed:

`docker exec hassio_audio sh -c "printf 'default-sample-format = s24le\ndefault-sample-rate = 96000\n' > /data/custom.conf"`

To add commands to an existing file:

`docker exec hassio_audio sh -c "printf 'default-sample-format = s24le\ndefault-sample-rate = 96000\n' >> /data/custom.conf"`